### PR TITLE
chore: update phi3 sha

### DIFF
--- a/.github/workflows/update-models.yaml
+++ b/.github/workflows/update-models.yaml
@@ -101,9 +101,7 @@ jobs:
             -t ${REGISTRY}/${MODEL_NAME}:${MODEL_SIZE}${MODEL_TYPE} \
             -f models/${{ matrix.model }}.yaml \
             --push --progress plain \
-            --sbom=true --provenance=true \
-            --cache-from=type=gha,scope=${MODEL_NAME}-${MODEL_SIZE} \
-            --cache-to=type=gha,scope=${MODEL_NAME}-${MODEL_SIZE},mode=max
+            --sbom=true --provenance=true
           echo "DIGEST=$(cosign triangulate ${REGISTRY}/${MODEL_NAME}:${MODEL_SIZE} --type digest)" >> $GITHUB_ENV
 
       - name: Sign the images with GitHub OIDC Token

--- a/models/phi-3-3.8b.yaml
+++ b/models/phi-3-3.8b.yaml
@@ -5,7 +5,7 @@ runtime: cuda
 models:
   - name: phi-3-3.8b
     source: https://huggingface.co/microsoft/Phi-3-mini-4k-instruct-gguf/resolve/main/Phi-3-mini-4k-instruct-q4.gguf
-    sha256: 4fed7364ee3e0c7cb4fe0880148bfdfcd1b630981efa0802a6b62ee52e7da97e
+    sha256: 8a83c7fb9049a9b2e92266fa7ad04933bb53aa1e85136b7b30f1b8000ff2edef
     promptTemplates:
       - name: chatMsg
         template: |


### PR DESCRIPTION
**What this PR does / why we need it**:
This seems to be changed from `4fed7364ee3e0c7cb4fe0880148bfdfcd1b630981efa0802a6b62ee52e7da97e` to `8a83c7fb9049a9b2e92266fa7ad04933bb53aa1e85136b7b30f1b8000ff2edef` somehow 
https://huggingface.co/microsoft/Phi-3-mini-4k-instruct-gguf/tree/main

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
